### PR TITLE
Revert "add public method to update quota in ConfigRepository"

### DIFF
--- a/proxy/src/main/java/ru/qatools/gridrouter/ConfigRepository.java
+++ b/proxy/src/main/java/ru/qatools/gridrouter/ConfigRepository.java
@@ -65,14 +65,11 @@ public class ConfigRepository implements BeanChangeListener<Browsers> {
         } else {
             LOGGER.info("Loading quota configuration file [{}]", filename);
             String user = FilenameUtils.getBaseName(filename.toString());
-            updateQuota(user, browsers);
+            userBrowsers.put(user, browsers);
+            routes.putAll(browsers.getRoutesMap());
+            LOGGER.info("Loaded quota configuration for [{}] from [{}]: \n\n{}",
+                    user, filename, browsers.toXml());
         }
-    }
-
-    public void updateQuota(String user, Browsers browsers) {
-        userBrowsers.put(user, browsers);
-        routes.putAll(browsers.getRoutesMap());
-        LOGGER.info("Loaded quota configuration for [{}]: \n\n{}", user, browsers.toXml());
     }
 
     public Map<String, String> getRoutes() {


### PR DESCRIPTION
This reverts commit 2a647335c2d6c492682c14208bc4467e253e0438.
The original commit was merged in https://github.com/seleniumkit/gridrouter/pull/4