### PR TITLE
Pass all regions to selection strategy as well

### DIFF
--- a/config/src/main/java/ru/qatools/gridrouter/config/HostSelectionStrategy.java
+++ b/config/src/main/java/ru/qatools/gridrouter/config/HostSelectionStrategy.java
@@ -7,7 +7,7 @@ import java.util.List;
  */
 public interface HostSelectionStrategy {
 
-    Region selectRegion(List<Region> regions);
+    Region selectRegion(List<Region> allRegions, List<Region> unvisitedRegions);
 
     Host selectHost(List<Host> hosts);
 

--- a/config/src/main/java/ru/qatools/gridrouter/config/RandomHostSelectionStrategy.java
+++ b/config/src/main/java/ru/qatools/gridrouter/config/RandomHostSelectionStrategy.java
@@ -21,8 +21,8 @@ public class RandomHostSelectionStrategy implements HostSelectionStrategy {
     }
 
     @Override
-    public Region selectRegion(List<Region> regions) {
-        return selectRandom(regions);
+    public Region selectRegion(List<Region> allRegions, List<Region> unvisitedRegions) {
+        return selectRandom(unvisitedRegions);
     }
 
     @Override

--- a/config/src/main/java/ru/qatools/gridrouter/config/SequentialHostSelectionStrategy.java
+++ b/config/src/main/java/ru/qatools/gridrouter/config/SequentialHostSelectionStrategy.java
@@ -7,15 +7,11 @@ import java.util.List;
  */
 public class SequentialHostSelectionStrategy implements HostSelectionStrategy {
 
-    private int regionIndex;
-
     private int hostIndex;
 
     @Override
-    public Region selectRegion(List<Region> regions) {
-        Region region = regions.get(regionIndex++ % regions.size());
-        regionIndex %= regions.size();
-        return region;
+    public Region selectRegion(List<Region> allRegions, List<Region> unvisitedRegions) {
+        return unvisitedRegions.get(0);
     }
 
     @Override

--- a/proxy/src/main/java/ru/qatools/gridrouter/RouteServlet.java
+++ b/proxy/src/main/java/ru/qatools/gridrouter/RouteServlet.java
@@ -98,15 +98,15 @@ public class RouteServlet extends HttpServlet {
 
         capabilityProcessorFactory.getProcessor(caps).process(caps);
 
-        List<Region> actualRegions = actualVersion.getRegions()
+        List<Region> allRegions = actualVersion.getRegions()
                 .stream().map(Region::copy).collect(toList());
-        List<Region> unusedRegions = new ArrayList<>(actualRegions);
+        List<Region> unvisitedRegions = new ArrayList<>(allRegions);
 
         int attempt = 0;
-        while (!actualRegions.isEmpty()) {
+        while (!allRegions.isEmpty()) {
             attempt++;
 
-            Region currentRegion = hostSelectionStrategy.selectRegion(unusedRegions);
+            Region currentRegion = hostSelectionStrategy.selectRegion(allRegions, unvisitedRegions);
             Host host = hostSelectionStrategy.selectHost(currentRegion.getHosts());
 
             String route = host.getRoute();
@@ -138,12 +138,12 @@ public class RouteServlet extends HttpServlet {
 
             currentRegion.getHosts().remove(host);
             if (currentRegion.getHosts().isEmpty()) {
-                actualRegions.remove(currentRegion);
+                allRegions.remove(currentRegion);
             }
 
-            unusedRegions.remove(currentRegion);
-            if (unusedRegions.isEmpty()) {
-                unusedRegions = new ArrayList<>(actualRegions);
+            unvisitedRegions.remove(currentRegion);
+            if (unvisitedRegions.isEmpty()) {
+                unvisitedRegions = new ArrayList<>(allRegions);
             }
         }
 

--- a/proxy/src/test/java/ru/qatools/gridrouter/QuotaReloadTest.java
+++ b/proxy/src/test/java/ru/qatools/gridrouter/QuotaReloadTest.java
@@ -41,7 +41,8 @@ public class QuotaReloadTest {
         replacePortInQuotaFile(USER_1, HUB_PORT_2);
         Thread.sleep(5000); // just to avoid multiple exceptions in the logs
         assertThat(USER_1, should(canObtain(firefox()))
-                .whileWaitingUntil(timeoutHasExpired().withPollingInterval(SECONDS.toMillis(3))));
+                .whileWaitingUntil(timeoutHasExpired(SECONDS.toMillis(60))
+                        .withPollingInterval(SECONDS.toMillis(3))));
     }
 
     @Test
@@ -49,7 +50,8 @@ public class QuotaReloadTest {
         copyQuotaFile(USER_1, USER_4, HUB_PORT_2);
         Thread.sleep(5000); // just to avoid multiple exceptions in the logs
         assertThat(USER_4, should(canObtain(firefox()))
-                .whileWaitingUntil(timeoutHasExpired().withPollingInterval(SECONDS.toMillis(3))));
+                .whileWaitingUntil(timeoutHasExpired(SECONDS.toMillis(60))
+                        .withPollingInterval(SECONDS.toMillis(3))));
     }
 
     @After


### PR DESCRIPTION
This change provides an option for a custom strategy to select all the same regions over and over again without trying others. This may be useful when the strategy contains some extra specific information about the regions and therefore may want to select a given region twice.

This PR does not change any logic in the default implementation.